### PR TITLE
Added loading spinner and normalize errors on registry page

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -124,7 +124,7 @@ router.post(
             });
         } catch (error) {
             console.error(error.message);
-            res.status(500).send("Internal Server Error");
+            res.status(500).send({ errors : [{msg: 'Internal Server Error'}]});
         }
     }
 );
@@ -187,7 +187,7 @@ router.post(
             });
         } catch (error) {
             console.error(error.message);
-            res.status(500).send("Internal Server Error");
+            res.status(500).send({ error : 'Internal Server Error'});
         }
     }
 );
@@ -200,7 +200,7 @@ router.post("/getuser", fetchuser, async (req, res) => {
         res.send(user);
     } catch (error) {
         console.error(error.message);
-        res.status(500).send("Internal Server Error");
+        res.status(500).send({ error : 'Internal Server Error'});
     }
 });
 

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -5,7 +5,12 @@ import "react-confirm-alert/src/react-confirm-alert.css"; // Import css
 import "../css/Login.css";
 import image from "../StuTea-Login.svg";
 
+
+
 const Login = () => {
+  
+  const [loading, setLoading] = useState(false);
+
   const host = process.env.REACT_APP_BACKEND_URL;
   let history = useNavigate();
   const init = {
@@ -28,6 +33,7 @@ const Login = () => {
   };
 
   const handleSubmit = async (e) => {
+    setLoading(true);
     e.preventDefault();
     const response = await fetch(`${host}/api/auth/login`, {
       method: "POST",
@@ -41,10 +47,12 @@ const Login = () => {
     });
     const json = await response.json();
     if (json.success) {
+      setLoading(false);
       localStorage.setItem("token", json.authtoken);
       history("/");
     } else {
       // alert("Enter valid credentials");
+      setLoading(false);
       incorrectCredentialsAlert();
     }
   };
@@ -91,9 +99,9 @@ const Login = () => {
             </div>
           </div>
           <div className="form-button">
-            <button type="submit"  className="form-submit-btn">
-              Login
-            </button>
+          {loading ? <div class="spinner-border text-danger" role="status">
+          <span class="sr-only">Loading...</span>
+                </div>: <button type="submit" className="form-submit-btn">Submit</button> }
           </div>
         </form>
       </div>

--- a/frontend/src/components/Register.js
+++ b/frontend/src/components/Register.js
@@ -1,9 +1,11 @@
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import { useNavigate } from 'react-router-dom'
 import "../css/Register.css"
 import { confirmAlert } from 'react-confirm-alert'; // Import
 import 'react-confirm-alert/src/react-confirm-alert.css'; // Import css
 import image from '../StuTea-Login.svg'
+
+
 
 export const Register = () => {
     const host = process.env.REACT_APP_BACKEND_URL;
@@ -15,11 +17,27 @@ export const Register = () => {
       firstname: "",
       lastname: "",
       city: ""
-  })
+  });
+
   const [errors, setErrors] = useState([]);
-  const [match, setMatch] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(()=>{
+    if (errors.length !== 0) {
+        confirmAlert({
+            message: errors[0].msg,
+            buttons: [
+              {
+                label: 'Close',
+                onClick: () => history('/register')
+              }
+            ]
+          });
+    }
+  }, [errors]);
 
   const handleSubmit = async (e)=> {
+    setLoading(true);
     e.preventDefault();
     const response = await fetch(`${host}/api/auth/register`, {
         method: "POST",
@@ -37,29 +55,19 @@ export const Register = () => {
     });
 
     const json = await response.json();
-    setErrors(json.errors);
-    if(json.error) {
-        setMatch(json.error);
+    if(json.errors) {
+        setErrors(json.errors);
+        setLoading(false);
     }
     if(json.success) {
         history(`/wait/${credentials.email}`);
+        setLoading(false);
     }
     else {
-        incorrectCredentialsAlert();
+        setLoading(false);
     }
 }
 
-const incorrectCredentialsAlert = () => {
-    confirmAlert({
-      message: match?(match.length?match:""):(errors.length?errors[0].msg:""),
-      buttons: [
-        {
-          label: 'Close',
-          onClick: () => history('/register')
-        }
-      ]
-    });
-  };
 
 const onChange = (e)=> {
   setCredentials({...credentials, [e.target.name]: e.target.value})
@@ -97,9 +105,12 @@ const onChange = (e)=> {
                     <input type="text" placeholder="Enter your city" className="rform-input" name="city" id="city" onChange={onChange} value={credentials.city}/>
                 </div>
                 <div className="form-button">
-                <button type="submit" className="form-submit-btn">
-                    Submit
-                </button>
+
+                
+                {loading ? <div class="spinner-border text-danger" role="status">
+                <span class="sr-only">Loading...</span>
+                </div>: <button type="submit" className="form-submit-btn">Submit</button> }
+                
                 </div>
             </form>
             </div>


### PR DESCRIPTION
I added the spinner loadings in register and login using boothstrap

![image](https://user-images.githubusercontent.com/61703285/216790666-d4a34a63-bb2d-4a5a-8617-0ff56524c2af.png)

And I normalized the errors between the backend and frontend in the registry page because having two variables to handle errors seems a little bit redundant.

I also fixed the try-catch response on the backend on the registry controller since some times the database connection would time out and the response returned by the backend was a plain string, and when frontend receive it const json = await response.json(); would throw exception since it couldn't parse any json

And I also fixed an issue that would prevent the pop-up error alert from showing any error message the first time an error would happen when registrying.